### PR TITLE
Add_Task7

### DIFF
--- a/Tasks/Makarau/Task7/movie_service/logic.py
+++ b/Tasks/Makarau/Task7/movie_service/logic.py
@@ -1,0 +1,45 @@
+import json
+
+with open ("movies.json", 'r') as f:
+    data = json.load(f)
+
+def add_movie(title,director,year,genre):
+    counter = 0
+    for i in data:
+        if i["title"] == title and i["director"] == director and i["year"] == year and i["genre"] == genre:
+            counter+=1
+    if counter == 0:
+        data.append({'title':title,'director':director,'year':year,'genre':genre})
+        res = "The movie was added"
+    else:
+        res = "This movie has been added before"         
+    with open ("movies.json", 'w') as f:
+        json.dump(data,f, indent=2)               
+    return res     
+    
+def get_all_movies():
+    try:    
+        for i in data:
+            yield (f'\ntitle: {i["title"]}\ndirector: {i["director"]}\nyear: {i["year"]}\ngenre: {i["genre"]}')
+    except RuntimeError:
+        raise RuntimeError ("An error occurred while getting data about all movies")
+
+def search_title(title):
+    for i in data:
+        if i["title"] == title:
+            yield (f'\ntitle: {i["title"]}\ndirector: {i["director"]}\nyear: {i["year"]}\ngenre: {i["genre"]}')        
+        
+def search_director(director):
+    for i in data:
+        if i["director"] == director:
+            yield (f'\ntitle: {i["title"]}\ndirector: {i["director"]}\nyear: {i["year"]}\ngenre: {i["genre"]}')
+
+def search_year(year):
+    for i in data:
+        if i["year"] == year:
+            yield (f'\ntitle: {i["title"]}\ndirector: {i["director"]}\nyear: {i["year"]}\ngenre: {i["genre"]}')
+
+def search_genre(genre):
+    for i in data:
+        if i["genre"] == genre:
+            yield (f'\ntitle: {i["title"]}\ndirector: {i["director"]}\nyear: {i["year"]}\ngenre: {i["genre"]}')

--- a/Tasks/Makarau/Task7/movie_service/movie_service.py
+++ b/Tasks/Makarau/Task7/movie_service/movie_service.py
@@ -1,0 +1,4 @@
+import ui
+
+if __name__ == "__main__":
+    ui.start()

--- a/Tasks/Makarau/Task7/movie_service/movies.json
+++ b/Tasks/Makarau/Task7/movie_service/movies.json
@@ -1,0 +1,32 @@
+[
+  {
+    "title": "The Green Mile",
+    "director": "Frank Darabont",
+    "year": "1999",
+    "genre": "drama"
+  },
+  {
+    "title": "The Shawshank Redemption",
+    "director": "Frank Darabont",
+    "year": "1994",
+    "genre": "drama"
+  },
+  {
+    "title": "Forrest Gump",
+    "director": "Robert Zemeckis",
+    "year": "1994",
+    "genre": "drama"
+  },
+  {
+    "title": "Schindlers List",
+    "director": "Steven Spielberg",
+    "year": "1993",
+    "genre": "biography"
+  },
+  {
+    "title": "Intouchables",
+    "director": "Olivier Nakache",
+    "year": "2011",
+    "genre": "comedy"
+  }
+]

--- a/Tasks/Makarau/Task7/movie_service/ui.py
+++ b/Tasks/Makarau/Task7/movie_service/ui.py
@@ -1,0 +1,99 @@
+import logic
+import validation
+
+def start():
+    while True:
+        answ = input("""
+            Choose the menu option
+            0.Quit the program         
+            1.Add a new movie to the collection
+            2.List all movies in the collection
+            3.Search for a movie by title, director, year, or genre
+        """).strip()
+        if answ == '0':
+            break
+        elif answ == '1':
+            add_movie()
+        elif answ == '2':
+            get_all_movies()
+        elif answ == '3':
+            search ()
+        else:
+            print("Choose only numbers presented in the list")
+            continue
+
+def ask_for_param(param):
+    value = input (f"Enter {param}\n")
+    return value
+
+def add_movie():    
+    title = ask_for_param("movie title :")
+    director = ask_for_param("director :")
+    year = ask_for_param("year :") 
+    genre = ask_for_param("genre :")
+    try:   
+        year = validation.check_info(year)
+    except ValueError:
+        print (f"\n{year} - An error occurred while passing the year value")
+        return
+    if year:
+        res = logic.add_movie(title,director,year,genre)
+        print(res)
+    else:
+        print("Something went wrong while processing info, please do again")
+
+def get_all_movies():
+    try:    
+        gen = (logic.get_all_movies())
+        for i in gen:
+            print(i)
+    except RuntimeError as e:
+        print(e)
+
+def search ():
+    while True:    
+        parameter_selection = input("""
+            Choose a menu option
+            0. Back to main menu
+            1. Search for movies by title
+            2. Search for movies by director
+            3. Search movies by year
+            4. Search movies by genre
+        """).strip()
+        if parameter_selection == '0':            
+            break
+        elif parameter_selection == '1':
+            search_title()
+        elif parameter_selection == '2':
+            search_director()
+        elif parameter_selection == '3':
+            search_year()
+        elif parameter_selection == '4':
+            search_genre()
+        else:
+            print("Choose only numbers presented in the list")
+            continue
+
+def search_title():
+    title = ask_for_param("movie title :")
+    gen = (logic.search_title(title))
+    for i in gen:
+        print(i)    
+
+def search_director():
+    director = ask_for_param("director :")
+    gen = (logic.search_director(director))
+    for i in gen:
+        print(i)
+
+def search_year():
+    year = ask_for_param("year :")
+    gen = (logic.search_year(year))
+    for i in gen:
+        print(i)
+
+def search_genre():
+    genre = ask_for_param("genre :")
+    gen = (logic.search_genre(genre))
+    for i in gen:
+        print(i)

--- a/Tasks/Makarau/Task7/movie_service/validation.py
+++ b/Tasks/Makarau/Task7/movie_service/validation.py
@@ -1,0 +1,12 @@
+import datetime
+
+first_film = 1895
+current_year = datetime.datetime.now().year
+
+def check_info(year):    
+    year = year.replace(" ",'')    
+    if not year:
+        return[]
+    elif first_film <= int(year) <= current_year and year.isdigit():        
+        return year
+    


### PR DESCRIPTION
Can the search_title(), search_director(), search_year(), and search_genre() generator functions be refactored to remain generators?

My version (but then one function generator is obtained): 

def f ():
    for i in data:
        yield (f'\ntitle: {i["title"]}\ndirector: {i["director"]}\nyear: {i["year"]}\ngenre: {i["genre"]}') 

def search_title(title):
    for i in data:
        if i["title"] == title:
            return f()

for i in search_title('title'):
    print(i)

